### PR TITLE
Core Team: suggested changes

### DIFF
--- a/2022q4/core.adoc
+++ b/2022q4/core.adoc
@@ -1,32 +1,34 @@
 === FreeBSD Core Team
 
+Link +
+link:https://www.freebsd.org/administration/#t-core[FreeBSD Core Team] URL: https://www.freebsd.org/administration/#t-core[https://www.freebsd.org/administration/#t-core] +
 Contact: FreeBSD Core Team <core@FreeBSD.org>
 
 The FreeBSD Core Team is the governing body of FreeBSD.
 
-==== Items
+==== Core Team Charter
 
-===== Core Team Charter
+A delegation of the current Team is working together with some members of the previous Team to draft a Core Team charter.
+There was a face-to-face meeting in the US on December 3 - 4 to discuss the new Charter.
+The same delegation also met with The FreeBSD Foundation Board on December 5th to discuss the collaboration details.
+The delegation will present to the rest of the Team and discuss the details in the first quarter of 2023.
 
-A delegation of the current core team is working together with some members of the previous Core Team to draft a core team charter.
-There was a face-to-face meeting in the US on December 3 - 4 to discuss the new charter.
-The delegation will present to the rest of the core team and discuss the details in the first quarter of 2023.
-The same delegation also had a meeting with the FreeBSD Foundation board on December 5th to discuss the collaboration details.
+==== Experimental Matrix IM solution
 
-===== Experimental Matrix IM solution
-
-The core team is working on evaluating Matrix as an instant messaging tool for the project.
+The Team is working on evaluating Matrix as an instant messaging tool for the project.
 This will make the project's communication channels less dependant on third parties.
 The service will be made available to the FreeBSD community to test and evaluate its validity at a later date.
 
-===== Committer's Guide
+https://matrix.org/
+
+==== Committer's Guide
 
 Deprecate BSD-2-Clause-FreeBSD and use BSD-2-Clause.
 For more information please refer to the link:https://cgit.freebsd.org/doc/commit/?id=a6e5d24925949785122a9f37f163d58239fd5484[commit].
 
-==== Commit bits
+=== Commit bits
 
-* Core approved the src commit bit for Zhenlei Huang (zlei@)
-* Core approved the src commit bit for Corvin Köhne (corvink@)
-* Core approved the src commit bit for Sumit Saxon (ssaxena@)
+* Core approved the src commit bit for Zhenlei Huang (zlei@).
+* Core approved the src commit bit for Corvin Köhne (corvink@).
+* Core approved the src commit bit for Sumit Saxon (ssaxena@).
 * Core approved the restore of the source commit bit for Paweł Jakub Dawidek (pjd@).

--- a/2022q4/core.adoc
+++ b/2022q4/core.adoc
@@ -1,0 +1,32 @@
+=== FreeBSD Core Team
+
+Contact: FreeBSD Core Team <core@FreeBSD.org>
+
+The FreeBSD Core Team is the governing body of FreeBSD.
+
+==== Items
+
+===== Core Team Charter
+
+A delegation of the current core team is working together with some members of the previous Core Team to draft a core team charter.
+There was a face-to-face meeting in the US on December 3 - 4 to discuss the new charter.
+The delegation will present to the rest of the core team and discuss the details in the first quarter of 2023.
+The same delegation also had a meeting with the FreeBSD Foundation board on December 5th to discuss the collaboration details.
+
+===== Experimental Matrix IM solution
+
+The core team is working on evaluating Matrix as an instant messaging tool for the project.
+This will make the project's communication channels less dependant on third parties.
+The service will be made available to the FreeBSD community to test and evaluate its validity at a later date.
+
+===== Committer's Guide
+
+Deprecate BSD-2-Clause-FreeBSD and use BSD-2-Clause.
+For more information please refer to the link:https://cgit.freebsd.org/doc/commit/?id=a6e5d24925949785122a9f37f163d58239fd5484[commit].
+
+==== Commit bits
+
+* Core approved the src commit bit for Zhenlei Huang (zlei@)
+* Core approved the src commit bit for Corvin Köhne (corvink@)
+* Core approved the src commit bit for Sumit Saxon (ssaxena@)
+* Core approved the restore of the source commit bit for Paweł Jakub Dawidek (pjd@).


### PR DESCRIPTION
Add a primary link. 

Remove the 'Items' heading, promote the subsequent headings. 

Core Team, core team … consistency with capitalisation. I suggest 'the Core Team', 'the Team', or 'Core' (as in the bullet points). 

Uppercase T for The FreeBSD Foundation and uppercase B for its Board. 

Chronological order for dated things in the paragraph about the Charter. 

Add a URL for Matrix. 

For each bullet point, below a heading, that is a complete sentence: end with a full stop. Consistent with changes to another report for this quarter.